### PR TITLE
Gosched fix for spinning cycles

### DIFF
--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -52,7 +52,7 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 				// we'll pass client and err on outside this loop
 			}
 
-			// time.Sleep(0)
+			time.Sleep(0)
 		}
 	}()
 

--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -52,7 +52,7 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 				// we'll pass client and err on outside this loop
 			}
 
-			time.Sleep(0)
+			time.Sleep(1)
 		}
 	}()
 

--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -39,6 +39,8 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 
 		// once is to make sure we only ever mark done one time
 		once := &sync.Once{}
+
+		// collect the done channel once so we don't keep copying a reference
 		doneCh := ctx.Done()
 
 		for {
@@ -52,7 +54,7 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 				// we'll pass client and err on outside this loop
 			}
 
-			time.Sleep(1)
+			time.Sleep(5 * time.Second)
 		}
 	}()
 

--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -47,7 +47,7 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 			select {
 			// global context is closed (server is shut down)
 			case <-doneCh:
-				break
+				return
 			case <-ticker.C:
 				cli, err = createClient(ctx, mtx, loginor)
 				once.Do(firstCreation.Done)

--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -2,6 +2,7 @@ package awsclientconfig
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"time"
 
@@ -50,6 +51,8 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 				once.Do(firstCreation.Done)
 				// we'll pass client and err on outside this loop
 			}
+
+			runtime.Gosched()
 		}
 	}()
 

--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -39,11 +39,12 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 
 		// once is to make sure we only ever mark done one time
 		once := &sync.Once{}
+		doneCh := ctx.Done()
 
 		for {
 			select {
 			// global context is closed (server is shut down)
-			case <-ctx.Done():
+			case <-doneCh:
 				break
 			case <-ticker.C:
 				cli, err = createClient(ctx, mtx, loginor)
@@ -51,7 +52,7 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 				// we'll pass client and err on outside this loop
 			}
 
-			time.Sleep(10 * time.Millisecond)
+			// time.Sleep(0)
 		}
 	}()
 

--- a/create_get_client_func.go
+++ b/create_get_client_func.go
@@ -2,7 +2,6 @@ package awsclientconfig
 
 import (
 	"context"
-	"runtime"
 	"sync"
 	"time"
 
@@ -52,7 +51,7 @@ func CreateGetClientFunc[T any](ctx context.Context, loginor Loginor, createClie
 				// we'll pass client and err on outside this loop
 			}
 
-			runtime.Gosched()
+			time.Sleep(10 * time.Millisecond)
 		}
 	}()
 


### PR DESCRIPTION
Add a return, replacing a break in the main loop. Also add a `time.Wait(5 * time.Seconds)` to the loop to prevent it from starving process resources.